### PR TITLE
Change HACS documentation installation from default to custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ You need to install the plugin manually or through [HACS], not both. If you inst
 
 ### Through HACS
 
-1. Go to `HACS` dashboard
-2. Go to `Frontend`
-3. Click on `Explore and download repositories` button in the bottom-right of the screen
-4. Search for `keep-texts-in-tabs` and install it
+The plugin is still not available in HACS default (it will be when [this](https://github.com/hacs/default/pull/2038) gets merged). For now, it should be installed through [HACS custom](https://hacs.xyz/docs/faq/custom_repositories/) adding https://github.com/elchininet/keep-texts-in-tabs to the custom repositories.
+
+[//]: # "1. Go to `HACS` dashboard"
+[//]: # "2. Go to `Frontend`"
+[//]: # "3. Click on `Explore and download repositories` button in the bottom-right of the screen"
+[//]: # "4. Search for `keep-texts-in-tabs` and install it"
 
 ### Manual installation
 


### PR DESCRIPTION
The plugin is still not in HACS default. Changing rhe documentation to state that it should be installed through HACS custom.