### PR TITLE
Fix an issue with missing tabs titles

### DIFF
--- a/src/keep-texts-in-tabs.ts
+++ b/src/keep-texts-in-tabs.ts
@@ -113,7 +113,7 @@ class KeepTextsInTabs {
         
         const paperTabsArray = paperTabs
             .map((paperTab: HTMLElement): Tab => {
-                const label = paperTab.getAttribute(ARIA_LABEL_ATTRIBUTE);
+                const label = paperTab.getAttribute(ARIA_LABEL_ATTRIBUTE) || '';
                 const span = paperTab.querySelector(`span.${NAMESPACE}`);
                 if (span) {
                     span.remove();


### PR DESCRIPTION
This pull request fixes an error that is being trhown if a user have a tab without title. From now on, if no title is set, an empty string is taking to do the operations so visually nothing will change.

Closes: #8 