### PR TITLE
Run build workflow in Github runner not in node16 image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,18 +7,22 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container:
-      image: node:16
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set-up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache
+          key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install deps
         run: yarn install --frozen-lockfile
       - name: E2E tests


### PR DESCRIPTION
This pull request runs the build workflow in the docker runner instead of in the Node16 image because `Docker` is not installed in this image.