### PR TITLE
Update home-assistant-query-selector to version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "home-assistant-query-selector": "^1.1.3"
+    "home-assistant-query-selector": "^2.1.0"
   }
 }

--- a/src/keep-texts-in-tabs.ts
+++ b/src/keep-texts-in-tabs.ts
@@ -32,8 +32,8 @@ class KeepTextsInTabs {
             } = event.detail;
             
             this.lovelace = await HA_PANEL_LOVELACE.element as Lovelace;
-            this.huiRoot = await HUI_ROOT.shadowRootQuerySelector('$');
-            this.appToolbar = await HEADER.querySelector(ELEMENT.TOOLBAR);
+            this.huiRoot = await HUI_ROOT.selector.$.element;
+            this.appToolbar = await HEADER.selector.query(ELEMENT.TOOLBAR).element;
             this.run();
         });
         selector.listen();

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,12 +340,12 @@ helpertypes@^0.0.19:
   resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
   integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
-home-assistant-query-selector@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/home-assistant-query-selector/-/home-assistant-query-selector-1.1.3.tgz#4c32ac377c5de28fa65b238459ccfe9e3fa7f13f"
-  integrity sha512-igL6IYQCytFGctI9gmXaYiBZn9GCT0jJa2F5qxLSlZjVHTavkohcv5xrxUlsIvOei18lV9HH3D6o1OcxvTV3vQ==
+home-assistant-query-selector@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-query-selector/-/home-assistant-query-selector-2.1.0.tgz#ce8a7591c7eee2bdc2c37108389534cb93626f6c"
+  integrity sha512-25E3omT04aBVLB/PPjTLfDE4F4ZjTGFZfo5qTfIFdY1HK6WcKWVx7PCZf3ISxVCUZtUKreIYaYswT8ZdSBxMrQ==
   dependencies:
-    shadow-dom-selector "^1.0.2"
+    shadow-dom-selector "^3.0.0"
 
 is-builtin-module@^3.2.1:
   version "3.2.1"
@@ -526,10 +526,10 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-shadow-dom-selector@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shadow-dom-selector/-/shadow-dom-selector-1.0.2.tgz#396700bacdf206eae444d845adf41042b362fe15"
-  integrity sha512-qezU/X48PFKlVecShKlOl7cZR0DjkXjRTxfFdU//o0VSP94KGwU3QdnBMqJzFbBbfpSf+xTL6llapSzhG1JxHw==
+shadow-dom-selector@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shadow-dom-selector/-/shadow-dom-selector-3.0.0.tgz#6a5ebac1bb69d600c5c9eafa0a9181f16a70cee5"
+  integrity sha512-9NmehVHs5xg1tUpZJ1aoiJQy3Up9cR2h/gHeXhaNGVSad328PzS/LoRQK3cPaLaYsJA0JfKfRdbUgrtwOITW6g==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This pull request updates the dependency `home-assistant-query-selector` and apply the changes that come with this new version.