### PR TITLE
Test configuration error

### DIFF
--- a/.hass/config/configuration.yaml
+++ b/.hass/config/configuration.yaml
@@ -39,6 +39,10 @@ lovelace:
       mode: yaml
       title: Override after
       filename: ui-lovelace-override-after.yaml
+    lovelace-config-with-error:
+      mode: yaml
+      title: Config with error
+      filename: ui-lovelace-config-with-error.yaml
 
 # Load frontend themes from the themes folder
 frontend:

--- a/.hass/config/ui-lovelace-config-with-error.yaml
+++ b/.hass/config/ui-lovelace-config-with-error.yaml
@@ -1,0 +1,10 @@
+keep_texts_in_tabs:
+  enabled: true
+  include:
+    - Muziek
+    - Alarmen
+  exclude:
+    - Windy
+    - Planten
+title: Config with error
+views: !include views.yaml

--- a/tests/main-options.spec.ts
+++ b/tests/main-options.spec.ts
@@ -70,6 +70,16 @@ test('Should be the same after a window resize', async ({ page }) => {
     await expect(page.locator(TABS_CONTENT_SELECTOR)).toHaveScreenshot('01-enabled.png');
 });
 
+test('Config with error', async ({ page }) => {
+    page.on('pageerror', error => {
+        expect(error.message).toBe('keep-texts-in-tabs: Configuration cannot have "include" and "exclude" properties at the same time');
+    });
+    await page.goto(
+        getLovelaceUrl('config-with-error')
+    );
+    await expect(page.locator(HEADER_SELECTOR)).toBeVisible();
+});
+
 test.describe('Small viewport', () => {
 
     test.use({ viewport: { width: 400, height: 600 } });


### PR DESCRIPTION
If a config has `include` and `exclude` parameters at the same time, an error is thrown. This pull request adds a test for this scenario.