### PR TITLE
If the enabled parameter is not set it should behave as no config

### DIFF
--- a/.hass/config/configuration.yaml
+++ b/.hass/config/configuration.yaml
@@ -43,6 +43,10 @@ lovelace:
       mode: yaml
       title: No Config
       filename: ui-lovelace-no-config.yaml
+    lovelace-not-enabled:
+      mode: yaml
+      title: Not Enabled
+      filename: ui-lovelace-not-enabled.yaml
     lovelace-config-with-error:
       mode: yaml
       title: Config with error

--- a/.hass/config/ui-lovelace-not-enabled.yaml
+++ b/.hass/config/ui-lovelace-not-enabled.yaml
@@ -1,0 +1,4 @@
+keep_texts_in_tabs:
+  position: after
+title: Not Enabled
+views: !include views.yaml

--- a/tests/main-options.spec.ts
+++ b/tests/main-options.spec.ts
@@ -68,6 +68,14 @@ test('No config', async ({ page }) => {
     await expect(page.locator(TABS_CONTENT_SELECTOR)).toHaveScreenshot('07-no-config.png');
 });
 
+test('Not enabled', async ({ page }) => {
+    await page.goto(
+        getLovelaceUrl('not-enabled')
+    );
+    await expect(page.locator(HEADER_SELECTOR)).toBeVisible();
+    await expect(page.locator(TABS_CONTENT_SELECTOR)).toHaveScreenshot('07-no-config.png');
+});
+
 test('Should be the same after a window resize', async ({ page }) => {
     await page.goto(
         getLovelaceUrl()


### PR DESCRIPTION
This pull request adds tests for not enabled parameter in the config. In these cases, it should behave as no configuration.