### PR TITLE
Cache Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Install deps
         run: yarn install --frozen-lockfile
       - name: E2E tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Install
         run: yarn install --frozen-lockfile
       - name: E2E tests


### PR DESCRIPTION
This pull request uses [ScribeMD/docker-cache](https://github.com/ScribeMD/docker-cache) action to cache Docker images during the workflow pipelines.