### PR TITLE
Update home-assistant-query-selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "home-assistant-query-selector": "^4.1.0"
+    "home-assistant-query-selector": "^4.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,10 +843,10 @@ helpertypes@^0.0.19:
   resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
   integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
-home-assistant-query-selector@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/home-assistant-query-selector/-/home-assistant-query-selector-4.1.0.tgz#d825fd12539001463d21abed41e8251fbb2be8d0"
-  integrity sha512-8FLanlFOFsg4WcZXwxUy2il2MhY9d3iUzxlaSJwWesHMu/xnnSmCNIqrASf460uEe1YU+WaXNlpZk0DYZg96RA==
+home-assistant-query-selector@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-query-selector/-/home-assistant-query-selector-4.2.0.tgz#009ef948f5b9079291a1bc0284c21efa39e82926"
+  integrity sha512-8VwrqTunsE3sgakCirBdQgrZTvWgT1SIaVthpgVCeaA/8dUK0qQfn3JFUcwaa8xm0NUa8yDgjRkxKe9lGHA65Q==
   dependencies:
     shadow-dom-selector "^4.1.2"
 


### PR DESCRIPTION
This pull request updates the `home-assistant-query-selector` dependency to the latest version.