### PR TITLE
Create Home Assistant Nightly beta tests Github workflow

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -1,0 +1,46 @@
+name: Home Assistant Nightly Beta Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:      
+  beta-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache
+          key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-ha-beta-v1-${{ runner.os }}-${{ hashFiles('.playwright_docker_version') }}
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: E2E Tests
+        run: TAG=beta yarn test:ci
+      - name: Create coverage
+        run: yarn coverage:report
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-report
+          path: |
+            playwright-report/
+            coverage/
+          retention-days: 30


### PR DESCRIPTION
This pull request implements Home Assistant Nightly beta tests through a Github workflow to test the plugin against the Home Assistant beta version to spot any error before the final version is released.