### PR TITLE
Get the Playwright version from package.json to build the Docker cache id

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,14 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+      - name: Set Playwright version
+        id: playwright-version
+        run: |
+          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.6
         with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install deps
         run: pnpm install
       - name: E2E tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,10 +22,14 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+      - name: Set Playwright version
+        id: playwright-version
+        run: |
+          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.6
         with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install
         run: pnpm install
       - name: E2E tests


### PR DESCRIPTION
This pull request gets the `Playwright` version from the `package.json` to create the `Docker Cache` id during the Github workflows.