### PR TITLE
Remove ScribeMD/docker-cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,14 +21,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Set Playwright version
-        id: playwright-version
-        run: |
-          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.6
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install deps
         run: pnpm install
       - name: E2E tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,14 +22,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Set Playwright version
-        id: playwright-version
-        run: |
-          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.6
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install
         run: pnpm install
       - name: E2E tests


### PR DESCRIPTION
This pull request removes the jobs to cache Docker images because it is slower than download the images from the Docker Hub.